### PR TITLE
Remove subTest in integration test (allows retried decorator to behave as expected)

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -34,8 +34,7 @@ class IntegrationTests(unittest.TestCase):
         if os.getenv('DEBUG_OUTPUT'):
             print("Example output \n" + output)
 
-        with self.subTest(msg="Verify if output contains 'Solution found for SEND + MORE = MONEY' \n"):
-            self.assertIn("Solution found for SEND + MORE = MONEY".upper(), output)
+        self.assertIn("Solution found for SEND + MORE = MONEY".upper(), output, msg="No solution found.")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This _should_ fix the frequent test failures. However, @hbarovertwo , I did run into one test run (on CircleCI) where the integration test failed 3 times consecutively..so this is perhaps not a complete fix. Will know more once this is merged.